### PR TITLE
Fixed game room coin glitch

### DIFF
--- a/Kitsune/ClubPenguin/Room.php
+++ b/Kitsune/ClubPenguin/Room.php
@@ -22,6 +22,10 @@ class Room {
 			$penguin->send("%xt%jx%{$penguin->room->internalId}%{$this->externalId}%");
 		} else {
 			if($this->isGame) {
+				if($penguin->room->externalId > 1000) {
+					return; //Insert any punishment here	
+				}
+				
 				$nonBlackholeGames = array(900, 909, 956, 950, 963, 121);
 				
 				if(in_array($this->externalId, $nonBlackholeGames)) {


### PR DESCRIPTION
Prevent players from playing games in their igloo
Ref: https://aureus.pw/topic/1470-fixing-the-most-popular-coins-glitch/?tab=comments#comment-7560